### PR TITLE
Update conda recipe so it is noarch: python

### DIFF
--- a/news/update-conda-recipe.rst
+++ b/news/update-conda-recipe.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Updated the conda recipe so that it is "noarch: python", meaning it does not need to be rebuilt for different Python versions.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,2 +1,0 @@
-"%PYTHON%" setup.py install
-if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,1 +1,0 @@
-$PYTHON setup.py install     # Python command to install the script. 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,43 +1,53 @@
-{% set name = "srt-py" %}
-{% set version = "0.0.0" %}
+{% set version = "1.1.1" %}
 
 package:
-  name: "{{ name|lower }}"
+  name: "srt-py"
   version: "{{ version }}"
 
 source:
   path: ../
 
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv
+
 requirements:
   host:
     - pip
+    - python >=3.6
     - setuptools
-    - python >=3.6
   run:
-    - python >=3.6
-    - numpy
-    - scipy
-    - rtl-sdr
-    - soapysdr
-    - soapysdr-module-rtlsdr
-    - gnuradio-core
-    - gnuradio-zeromq
-    - gnuradio-osmosdr
-    - digital_rf
-    - pyzmq
-    - pyserial
     - astropy
-    - yamale
     - dash
     - dash-bootstrap-components
     - dash-html-components
     - dash-core-components
-    - plotly
+    - digital_rf
+    - gnuradio-core
+    - gnuradio-zeromq
+    - gnuradio-osmosdr
     - pandas
+    - plotly
+    - pyserial
+    - python >=3.6
+    - pyzmq
+    - numpy
+    - rtl-sdr
+    - scipy
+    - soapysdr
+    - soapysdr-module-rtlsdr
     - waitress
+    - yamale
 
 test:
   requires:
     - pytest
   imports:
     - srt
+
+about:
+  home: https://github.com/MITHaystack/srt-py
+  summary: Small Radio Telescope Control Code for Python
+  license: MIT
+  license_file: license

--- a/rever.xsh
+++ b/rever.xsh
@@ -13,9 +13,11 @@ $ACTIVITIES = [
                ]
 
 
+$TAG_TEMPLATE = 'v$VERSION'
 $VERSION_BUMP_PATTERNS = [  # These note where/how to find the version numbers
                          ('srt/__init__.py', r'__version__\s*=.*', "__version__ = '$VERSION'"),
-                         ('setup.py', r'version\s*=.*,', "version='$VERSION',")
+                         ('setup.py', r'version\s*=.*,', "version='$VERSION',"),
+                         ('recipe/meta.yaml', r'{%\s*set\s*version\s*=.*', '{% set version = "$VERSION" %}')
                          ]
 $CHANGELOG_FILENAME = 'CHANGELOG.rst'  # Filename for the changelog
 $CHANGELOG_TEMPLATE = 'TEMPLATE.rst'  # Filename for the news template


### PR DESCRIPTION
Fixes #19.

Also, I updated the rever config so that it will bump the conda package version as well, and so that the version tag will be `v$VERSION` when rever is run with `$VERSION` meaning that all of the replaced version values can be numeric as intended.